### PR TITLE
Add command line interface for executing js files using the interpreter

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,3 +22,9 @@ var myInterpreter = new Interpreter('2 * 2');
 import Interpreter from 'js-interpreter';
 const myInterpreter = new Interpreter('2 * 2');
 ```
+
+## Using command line interface
+
+```
+js-interpreter path/to/my/file.js
+```

--- a/bin/run.js
+++ b/bin/run.js
@@ -1,0 +1,31 @@
+#!/usr/bin/env node
+
+var fs = require('fs');
+var Interpreter = require('../src/interpreter');
+
+// add native console object to global interpreter scope
+function initConsole(interpreter, scope) {
+  var myConsole = interpreter.createObject(interpreter.OBJECT);
+  interpreter.setProperty(
+    scope,
+    'console',
+    myConsole
+  );
+
+  // add log function to console object
+  function myLog() {
+    for (var j = 0; j < arguments.length; j++) {
+      arguments[j] = interpreter.pseudoToNative(arguments[j]);
+    }
+    return interpreter.createPrimitive(console.log.apply(console, arguments));
+  }
+  interpreter.setProperty(
+    myConsole,
+    'log',
+    interpreter.createNativeFunction(myLog),
+    Interpreter.NONENUMERABLE_DESCRIPTOR
+  );
+}
+
+var code = fs.readFileSync(process.argv[process.argv.length - 1], 'utf-8');
+new Interpreter(code, initConsole).run();

--- a/package.json
+++ b/package.json
@@ -20,5 +20,6 @@
   "devDependencies": {
     "acorn": "^4.0.3",
     "webpack": "^1.14.0"
-  }
+  },
+  "bin": "bin/run.js"
 }


### PR DESCRIPTION
Thanks for turning this project into an npm package! I'm looking into potentially using it for [code.org](https://github.com/code-dot-org/code-dot-org).

As part of using this package, I'm working on hooking up the [Official ECMAScript Conformance Test Suite](https://github.com/tc39/test262) using https://github.com/bterlson/test262-harness. It's pretty easy to hook up if you have a command line interface, so I've added one with this pull request.